### PR TITLE
Add Hexadecimal Serialization/Deserialization for Felt Type

### DIFF
--- a/crates/starknet-types-core/Cargo.toml
+++ b/crates/starknet-types-core/Cargo.toml
@@ -15,6 +15,7 @@ lambdaworks-math = { version = "0.10.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
+serde_with = { version = "3.11.0", default-features = false }
 
 # Optional
 arbitrary = { version = "1.3", optional = true }
@@ -45,6 +46,7 @@ prime-bigint = ["dep:lazy_static"]
 num-traits = []
 papyrus-serialization = ["std"]
 
+
 [dev-dependencies]
 proptest = "1.5"
 regex = "1.11"
@@ -53,6 +55,7 @@ criterion = "0.5"
 rand_chacha = "0.3"
 rand = "0.8"
 lazy_static = { version = "1.5", default-features = false }
+
 
 [[bench]]
 name = "criterion_hashes"

--- a/crates/starknet-types-core/src/felt/mod.rs
+++ b/crates/starknet-types-core/src/felt/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod felt_arbitrary;
 mod primitive_conversions;
+pub mod ufe_hex;
 
 use core::ops::{Add, Mul, Neg};
 use core::str::FromStr;

--- a/crates/starknet-types-core/src/felt/ufe_hex.rs
+++ b/crates/starknet-types-core/src/felt/ufe_hex.rs
@@ -1,0 +1,138 @@
+use super::Felt;
+use core::fmt::{self, Formatter};
+use serde::{
+    de::{Error as DeError, Visitor},
+    Deserializer, Serializer,
+};
+use serde_with::{DeserializeAs, SerializeAs};
+
+pub struct UfeHex;
+
+#[allow(dead_code)]
+pub struct UfeHexOption;
+
+#[allow(dead_code)]
+pub struct UfePendingBlockHash;
+
+struct UfeHexVisitor;
+struct UfeHexOptionVisitor;
+struct UfePendingBlockHashVisitor;
+
+impl SerializeAs<Felt> for UfeHex {
+    fn serialize_as<S>(value: &Felt, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{value:#x}"))
+    }
+}
+
+impl<'de> DeserializeAs<'de, Felt> for UfeHex {
+    fn deserialize_as<D>(deserializer: D) -> Result<Felt, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UfeHexVisitor)
+    }
+}
+
+impl<'de> Visitor<'de> for UfeHexVisitor {
+    type Value = Felt;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: DeError,
+    {
+        Felt::from_hex(v).map_err(|err| DeError::custom(format!("invalid hex string: {err}")))
+    }
+}
+
+impl SerializeAs<Option<Felt>> for UfeHexOption {
+    fn serialize_as<S>(value: &Option<Felt>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_str(&format!("{value:#064x}")),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> DeserializeAs<'de, Option<Felt>> for UfeHexOption {
+    fn deserialize_as<D>(deserializer: D) -> Result<Option<Felt>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UfeHexOptionVisitor)
+    }
+}
+
+impl<'de> Visitor<'de> for UfeHexOptionVisitor {
+    type Value = Option<Felt>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: DeError,
+    {
+        match v {
+            "" => Ok(None),
+            _ => match Felt::from_hex(v) {
+                Ok(value) => Ok(Some(value)),
+                Err(err) => Err(DeError::custom(format!("invalid hex string: {err}"))),
+            },
+        }
+    }
+}
+
+impl SerializeAs<Option<Felt>> for UfePendingBlockHash {
+    fn serialize_as<S>(value: &Option<Felt>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_str(&format!("{value:#064x}")),
+            // We don't know if it's `null` or `"pending"`
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+impl<'de> DeserializeAs<'de, Option<Felt>> for UfePendingBlockHash {
+    fn deserialize_as<D>(deserializer: D) -> Result<Option<Felt>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UfePendingBlockHashVisitor)
+    }
+}
+
+impl<'de> Visitor<'de> for UfePendingBlockHashVisitor {
+    type Value = Option<Felt>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: DeError,
+    {
+        if v.is_empty() || v == "pending" || v == "None" {
+            Ok(None)
+        } else {
+            match Felt::from_hex(v) {
+                Ok(value) => Ok(Some(value)),
+                Err(err) => Err(DeError::custom(format!("invalid hex string: {err}"))),
+            }
+        }
+    }
+}


### PR DESCRIPTION

# Pull Request type
- Feature

## What is the current behavior?
Currently, there is no custom support for serializing or deserializing the Felt type as hexadecimal strings in the project.

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added support for serializing the Felt type into hexadecimal format using the SerializeAs trait.
- Implemented deserialization for the Felt type from hex strings, allowing conversion back from string format.
- Added support for Option<Felt> type, which can serialize and deserialize both Some(Felt) and None values.
- Introduced UfePendingBlockHash to handle Option<Felt> with support for "pending" or None states.

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced serialization and deserialization for `Felt` types using hexadecimal string representations.
	- Added structures for handling optional `Felt` values and pending block hashes with robust error management.
	- Added a new module for improved functionality related to hexadecimal representations.
	- Introduced a new benchmark for performance testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->